### PR TITLE
IOS - Error wallet file corrupt fixed

### DIFF
--- a/ios/RPCModule.m
+++ b/ios/RPCModule.m
@@ -125,8 +125,10 @@ RCT_REMAP_METHOD(createNewWallet,
     
     RCTLogInfo(@"Got seed: %@", seedStr);
     
-    // Also save the wallet after create
-    [self saveWalletInternal];
+    if (![seedStr hasPrefix:@"Error"]) {
+      // Also save the wallet after create
+      [self saveWalletInternal];
+    }
     
     resolve(seedStr);
   }


### PR DESCRIPTION
If you for instance don't have wifi/mobile service... and you start the App with the internal storage empty... and you try to create new wallet you got an Error (could be another type of error from the server).

That's fine.

When you have wifi/mobile service or the server is working correctly and you start the App again, you are trying to open an existing wallet, but in this case the wallet file inside of your device are corrupt.

You got this error: (and the App is totally stuck/blocked)

https://user-images.githubusercontent.com/43755989/215613883-df8f059c-b33a-4ba1-9fee-48842eda4652.MP4

How to reproduce in IOS:
* turn off wifi and mobile service (only for having an error with the server).
* open ZecWallet App with internal storage empty (new installation or internal storage clean).
* click on `Create new wallet` (you got an error from the server).
* ...
* turn on wifi or/and mobile service.
* open ZecWallet App again (you got the Corrupt wallet file Error when the App is trying to open the corrupt wallet file stored in the device).